### PR TITLE
Update strafe sprint fix to v1.2

### DIFF
--- a/moddb.json
+++ b/moddb.json
@@ -110,9 +110,9 @@
         "image": "https://avatars.githubusercontent.com/u/81803926?v=4",
         "versions": [
             {
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "assets": {
-                    "x86_64": "https://github.com/CrackedMatter/mcpelauncher-strafe-sprint-fix/releases/download/v1.1/libmcpelauncherstrafesprintfix.so"
+                    "x86_64": "https://github.com/CrackedMatter/mcpelauncher-strafe-sprint-fix/releases/download/v1.2/libmcpelauncherstrafesprintfix.so"
                 }
             }
         ]


### PR DESCRIPTION
This update is backwards-compatible with older Minecraft versions, so it is not necessary to provide older mod versions.