### PR TITLE
add zoom v1.1 and snaplook v1.0.1

### DIFF
--- a/moddb.json
+++ b/moddb.json
@@ -787,6 +787,14 @@
                     "x86_64": "https://github.com/GameParrot/mcpelauncher-zoom/releases/download/v1.0/zoom-android-x86_64.zip"
                 },
                 "minecraft": "> 1.20.999"
+            },
+            {
+                "version": "1.1",
+                "assets": {
+                    "arm64-v8a": "https://github.com/GameParrot/mcpelauncher-zoom/releases/download/v1.1/zoom-android-arm64-v8a.zip",
+                    "x86_64": "https://github.com/GameParrot/mcpelauncher-zoom/releases/download/v1.1/zoom-android-x86_64.zip"
+                },
+                "minecraft": "> 1.20.999"
             }
         ]
     },
@@ -801,6 +809,14 @@
                 "assets": {
                     "arm64-v8a": "https://github.com/GameParrot/mcpelauncher-snaplook/releases/download/v1.0/snaplook-android-arm64-v8a.zip",
                     "x86_64": "https://github.com/GameParrot/mcpelauncher-snaplook/releases/download/v1.0/snaplook-android-x86_64.zip"
+                },
+                "minecraft": "> 1.20.999"
+            },
+            {
+                "version": "1.0.1",
+                "assets": {
+                    "arm64-v8a": "https://github.com/GameParrot/mcpelauncher-snaplook/releases/download/v1.0.1/snaplook-android-arm64-v8a.zip",
+                    "x86_64": "https://github.com/GameParrot/mcpelauncher-snaplook/releases/download/v1.0.1/snaplook-android-x86_64.zip"
                 },
                 "minecraft": "> 1.20.999"
             }


### PR DESCRIPTION
added updated versions for zoom and snaplook, which would crash the game or wont work on the latest game version.